### PR TITLE
Quick Start Install / userns / fakeroot rework

### DIFF
--- a/admin_quickstart.rst
+++ b/admin_quickstart.rst
@@ -2,103 +2,44 @@
 Admin Quick Start
 =================
 
-This document will cover installation and administration points of Singularity
-on a Linux host. This will also cover an overview of :ref:`configuring
-Singularity <configuring_overview>`, :ref:`Singularity architecture
-<singularity-architecture>`, and :ref:`the Singularity security model <singularity-security>`.
-
-For any additional help or support contact the
-`Sylabs team <https://www.sylabs.io/contact/>`_, or send a email to
-`support@sylabs.io <mailto:support@sylabs.io>`_.
-
-------------
-Installation
-------------
-
-This section will explain how to install Singularity from an RPM. If you want
-more information on installation, including alternate installation procedures
-and options for other operating systems, see the `user guide installation page
-<https://www.sylabs.io/guides/\{userversion\}/user-guide/installation.html>`_.
-
-Install Dependencies
---------------------
-
-Before we build the RPM, we need to install some dependencies:
-
-.. code-block:: none
-
-    $ sudo yum -y update && sudo yum -y install \
-        wget \
-        rpm-build \
-        git \
-        gcc \
-        libuuid-devel \
-        openssl-devel \
-        libseccomp-devel \
-        squashfs-tools \
-        epel-release
-    $ sudo yum -y install golang
-
-
-Download and Build the RPM
---------------------------
-
-The Singularity tarball for building the RPM is available on `the Github release
-page <https://github.com/sylabs/singularity/releases>`_.
-
-.. code-block:: none
-
-    $ export VERSION=3.0.2  # this is the singularity version, change as you need
-
-    $ wget https://github.com/sylabs/singularity/releases/download/v${VERSION}/singularity-${VERSION}.tar.gz && \
-        rpmbuild -tb singularity-${VERSION}.tar.gz && \
-        sudo rpm --install -vh ~/rpmbuild/RPMS/x86_64/singularity-${VERSION}-1.el7.x86_64.rpm && \
-        rm -rf ~/rpmbuild singularity-${VERSION}*.tar.gz
-
-Setting ``localstatedir``
--------------------------
-
-The local state directories used by ``singularity`` at runtime will be placed
-under the supplied ``prefix`` option. This will cause issues if that directory
-tree is read-only or if it is shared between several hosts or nodes that might
-run ``singularity`` simultaneously.
-
-In such cases, you should specify the ``localstatedir`` option. This will
-override the ``prefix`` option, instead placing the local state directories
-within the path explicitly provided. Ideally this should be within the local
-filesystem, specific to only a single host or node.
-
-In the case of a cluster, admins must ensure that the ``localstatedir`` exists
-on all nodes with ``root:root`` ownership and ``0755`` permissions
-
-.. code-block:: none
-
-    rpmbuild -tb --define='_localstatedir /mnt' singularity-${VERSION}.tar.gz
-
-.. _configuring_overview:
-
--------------
-Configuration
--------------
-
-There are several ways to configuring Singularity. Head over to the
-:ref:`Configuration files <singularity_configfiles>` section where most of the
-conf files and setting of configuration options are discussed.
+This quick start gives an overview of installation of Singularity from
+source, a description of the architecture of Singularity, and
+pointers to configuration files. More information, including alternate
+installation options and detailed configuration options can be found
+later in this guide.
+    
+For additional help or support contact the `Sylabs team
+<https://www.sylabs.io/contact/>`__.
 
 .. _singularity-architecture:
 
-------------------------
-Singularity Architecture
-------------------------
+---------------------------
+Architecture of Singularity
+---------------------------
 
-The architecture of Singularity allows containers to be executed as if they were
-native programs or scripts on a host system.
+Singularity is designed to allow containers to be executed as if they
+were native programs or scripts on a host system. No daemon is
+required to build or run containers, and the security model is compatible
+with shared systems.
 
-As a result, integration with schedulers such as Univa Grid Engine, Torque,
-SLURM, SGE, and many others is as simple as running any other command. All
-standard input, output, errors, pipes, IPC, and other communication pathways
-used by locally running programs are synchronized with the applications running
-locally within the container.
+As a result, integration with clusters and schedulers such as Univa
+Grid Engine, Torque, SLURM, SGE, and many others is as simple as
+running any other command. All standard input, output, errors, pipes,
+IPC, and other communication pathways used by locally running programs
+are synchronized with the applications running locally within the
+container.
+
+Singularity favors an 'integration over isolation' approach to
+containers. By default only the mount namespace is isolated for
+containers, so that they have their own filesystem view. Access to
+hardware such as GPUs, high speed networks, and shared filesystems is
+easy and does not require special configuration. User home
+directories, ``/tmp`` space, and installation specific mounts make it
+simple for users to benefit from the reproducibility of containerized
+applications without major changs to their existing workflows. Where
+more complete isolation is important, Singularity can use additional
+Linux namespaces and other security and resource limits to accomplish
+this.
 
 .. _singularity-security:
 
@@ -106,213 +47,234 @@ locally within the container.
 Singularity Security
 --------------------
 
-Security of the Container Runtime
----------------------------------
+Singularity uses a number of strategies to provide safety and
+ease-of-use on both single-user and shared systems. Notable security
+features include:
 
-The Singularity security model is unique among container platforms. The bottom
-line? **Untrusted users** (those who don't have root access and aren't getting
-it) can run **untrusted containers** (those that have not been vetted by admins)
-**safely**. There are a few pieces of the model to consider.
+ - The user inside a container is the same as the user who ran the
+   container. This means access to files and devices from the
+   container is easily controlled with standard POSIX permissions.
+ - Container filesystems are mounted ``nosuid`` and container
+   applications run with the ``PR_NO_NEW_PRIVS`` flag set. This means
+   that applications in a container cannot gain additional
+   privileges. A regular user cannot ``sudo`` or otherwise gain root
+   privilege on the host via a container.
+ - The Singularity Image Format (SIF) supports encryption of containers,
+   as well as cryptographic signing and verification of their content.
+ - SIF containers are immutable and their payload is run directly,
+   without extraction to disk. This means that the container can
+   always be verified, even at runtime, and encrypted content is not
+   exposed on disk.
+ - Restrictions can be configured to limit the ownership, location, and
+   cryptographic signatures of containers that are permitted to be run.
 
-First, Singularity's design forces a user to have the same UID and GID context
-inside and outside of the container. This is accomplished by dynamically writing
-entries to ``/etc/passwd`` and ``/etc/groups`` at runtime. This design makes it
-trivially easy for a user inside the container to safely read and write data to
-the host system with correct ownership, and it's also a cornerstone of the
-Singularity security context.
+To support the SIF image format, automated networking setup etc., and
+older Linux distributions without user namespace support, Singularity
+runs small amounts of privileged container setup code via a
+``starter-setuid`` binary. This is a 'setuid root' binary, so that
+Singularity can perform filesystem loop mounts and other operations
+that need privilege. The setuid flow is the default mode of operation,
+but :ref:`can be disabled <install-nonsetuid>` on build, or in the
+``singularity.conf`` configuration file if required.
 
-Second, Singularity mounts the container file system with the ``nosuid`` flag
-and executes processes within the container with the ``PR_SET_NO_NEW_PRIVS``
-bit set. Combined with the fact that the user is the same inside and outside of
-the container, this prevents a user from escalating privileges.
+.. note::
 
-Taken together, this design means your users can run whatever containers they
-want, and you don't have to worry about them damaging your precious system.
+   Running Singularity in non-setuid mode requires unprivileged user
+   namespace support in the operating system kernel and does not
+   support all features, most notably direct mounts of SIF
+   images. This impacts integrity/security guarantees of containers at
+   runtime.
 
-Security of the Container Itself
---------------------------------
+   See the :ref:`non-setuid installation section <install-nonsetuid>` for further
+   detail on how to install singularity to run in non-setuid mode.
 
-A malicious container may not be able to damage your system, but it could still
-do harm in the user's space without escalating privileges.
+------------------------
+Installation from Source
+------------------------
 
-Starting in Singularity 3.0, containers may be cryptographically signed when
-they are built and verified at runtime via PGP keys. This allows a user to
-ensure that a container is a bit-for-bit reproduction of the container produced
-by the original author before they run it. As long as the user trusts the
-individual or company that created the container, they can run the container
-without worrying.
+Singularity Community Edition can be installed from source directly,
+or by building an RPM package from the source. Various Linux
+distributions also package Singularity, but their packages may not be
+up-to-date with the upstream version on GitHub.
 
-Key signing and verification is made easy using the `Sylabs Keystore
-infrastructure <https://cloud.sylabs.io/keystore>`_. Join the party! And get
-more information about signing and verifying in the `Singularity user guide
-<https://www.sylabs.io/guides/\{userversion\}/user-guide/signNverify.html>`_.
+To install Singularity directly from source, follow the procedure
+below. Other methods are discussed in the :ref:`Installation
+<installation>` section.
 
-Administrator Control of Users' Containers
+.. Note::
+   
+    This quick-start that you will install as ``root`` using
+    ``sudo``, so that Singularity uses the default ``setuid``
+    workflow, and all features are available. See the :ref:`non-setuid
+    installation <install-nonsetuid>` section of this guide for detail
+    of how to install as a non-root user, and how this affects the
+    functionality of Singularity.
+
+ 
+Install Dependencies
+--------------------
+
+On Red Hat Enterprise Linux or CentOS install the following dependencies:
+
+.. code-block:: sh
+
+   $ sudo yum update -y && \
+        sudo yum groupinstall -y 'Development Tools' && \
+        sudo yum install -y \
+        openssl-devel \
+        libuuid-devel \
+        libseccomp-devel \
+        wget \
+        squashfs-tools \
+        cryptsetup
+
+        
+On Ubuntu or Debian install the following dependencies:
+
+.. code-block:: sh
+
+    $ sudo apt-get update && sudo apt-get install -y \
+        build-essential \
+        uuid-dev \
+        libgpgme-dev \
+        squashfs-tools \
+        libseccomp-dev \
+        wget \
+        pkg-config \
+        git \
+        cryptsetup-bin
+
+Install Go
+----------
+
+Singularity v3 is written primarily in Go, and you will need Go 1.13
+or above installed to compile it from source. Versions of Go packaged
+by your distribution may not be new enough to build Singularity.
+
+The method below is one of several ways to `install and configure Go
+<https://golang.org/doc/install>`_.
+
+.. note::
+
+   If you have previously installed Go from a download, rather than an
+   operating system package, you should remove your ``go`` directory,
+   e.g. ``rm -r /usr/local/go`` before installing a newer
+   version. Extracting a new version of Go over an existing
+   installation can lead to errors when building Go programs, as it
+   may leave old files, which have been removed or replaced in newer
+   versions.
+
+
+Visit the `Go download page <https://golang.org/dl/>`_ and pick a package
+archive to download. Copy the link address and download with wget.  Then extract
+the archive to ``/usr/local`` (or use other instructions on go installation
+page).
+
+.. code-block:: none
+
+    $ export VERSION=1.13.5 OS=linux ARCH=amd64 && \
+        wget https://dl.google.com/go/go$VERSION.$OS-$ARCH.tar.gz && \
+        sudo tar -C /usr/local -xzvf go$VERSION.$OS-$ARCH.tar.gz && \
+        rm go$VERSION.$OS-$ARCH.tar.gz
+
+Then, set up your environment for Go.
+
+.. code-block:: none
+
+    $ echo 'export GOPATH=${HOME}/go' >> ~/.bashrc && \
+        echo 'export PATH=/usr/local/go/bin:${PATH}:${GOPATH}/bin' >> ~/.bashrc && \
+        source ~/.bashrc
+
+
+Download Singularity from a GitHub release
 ------------------------------------------
 
-Singularity provides several ways for administrators to control the specific
-containers that users can run.
+You can download Singularity from one of the releases. To see a full list, visit
+`the GitHub release page <https://github.com/sylabs/singularity/releases>`_.
+After deciding on a release to install, you can run the following commands to
+proceed with the installation.
 
-* Admins can set directives in the ``singularity.conf`` file to limit container access.
+.. code-block:: none
 
-	* `limit container owners`: Only allow containers to be used when they are owned by a given user (default empty)
-	* `limit container groups`: Only allow containers to be used when they are owned by a given group (default empty)
-	* `limit container paths`: Only allow containers to be used that are located within an allowed path prefix (default empty)
-	* `allow container squashfs`: Limit usage of image containing squashfs filesystem (default yes)
-	* `allow container extfs`: Limit usage of image containing ext3 filesystem (default yes)
-	* `allow container dir`: Limit usage of directory image (default yes)
+    $ export VERSION={InstallationVersion} && # adjust this as necessary \
+        wget https://github.com/sylabs/singularity/releases/download/v${VERSION}/singularity-${VERSION}.tar.gz && \
+        tar -xzf singularity-${VERSION}.tar.gz && \
+        cd singularity
 
-* Admins can also whitelist or blacklist containers through the ECL (Execution Control List) located in ``ecl.toml``. This method is available in >=3.0:
 
-    This file describes execution groups in which SIF (default format since 3.0) images are checked for authorized loading/execution. The decision is made by validating both the location of the SIF file and by checking against a list of signing entities.
+Compile & Install Singularity
+-----------------------------
 
-Fakeroot feature
+Singularity uses a custom build system called ``makeit``.  ``mconfig`` is called
+to generate a ``Makefile`` and then ``make`` is used to compile and install.
+
+.. code-block:: none
+
+    $ ./mconfig && \
+        make -C ./builddir && \
+        sudo make -C ./builddir install
+
+By default Singularity will be installed in the ``/usr/local`` directory
+hierarchy. You can specify a custom directory with the ``--prefix`` option, to
+``mconfig``:
+
+.. code-block:: none
+
+    $ ./mconfig --prefix=/opt/singularity
+
+This option can be useful if you want to install multiple versions of
+Singularity, install a personal version of Singularity on a shared system, or if
+you want to remove Singularity easily after installing it.
+
+For a full list of ``mconfig`` options, run ``mconfig --help``.  Here
+are some of the most common options that you may need to use when
+building Singularity from source.
+
+- ``--sysconfdir``: Install read-only config files in sysconfdir.
+  This option is important if you need the ``singularity.conf`` file
+  or other configuration files in a custom location.
+
+- ``--localstatedir``: Set the state directory where containers are
+  mounted. This is a particularly important option for administrators
+  installing Singularity on a shared file system.  The
+  ``--localstatedir`` should be set to a directory that is present on
+  each individual node.
+
+- ``-b``: Build Singularity in a given directory. By default this is
+  ``./builddir``.
+
+-------------
+Configuration
+-------------
+
+Singularity is configured using files under ``etc/singularity`` in
+your ``--prefix``, or ``--syconfdir`` if you used that option with
+``mconfig``. In a default installation from source without a
+``--prefix`` set you will find them under
+``/usr/local/etc/singularity``.
+
+You can edit these files directly, or using the ``singularity config
+global`` command as the root user to manage them.
+
+``singularity.conf`` contains the majority of options controlling the
+runtime behaviour of Singularity. Additional files control security,
+network, and resource configuration. Head over to the
+:ref:`Configuration files <singularity_configfiles>` section where the
+files and configuration options are discussed.
+
+----------------
+Test Singularity
 ----------------
 
-Fakeroot (or commonly referred as rootless mode) allows an unprivileged user to run a container
-as a **"fake root"** user by leveraging `user namespace UID/GID mapping <http://man7.org/linux/man-pages/man7/user_namespaces.7.html>`_.
-
-.. note:: 
-
-	This feature requires a Linux kernel >= 3.8, but the recommended version is >= 3.18
-
-
-Some distributions doesn't enable user namespace by default, so you will need to enable
-it to use fakeroot:
+You can run a quick test of Singularity using a container in the
+Sylabs Container Library:
 
 .. code-block:: none
 
-  $ sudo sysctl -w user.max_user_namespaces=10000
-
-.. note::
-
-  If the above command doesn't work, please refer to the documentation of your
-  distribution documentation to figure out how to enable user namespace
-
-For unprivileged installation of Singularity or if ``allow setuid = no`` is set in ``singularity.conf``,
-Singularity attempts to use external **setuid binaries** ``newuidmap`` and ``newgidmap``, so you need to
-install those binaries on your system.
-
-.. note::
-
-  CentOS/RHEL 7 doesn't provide package for ``newuidmap`` and ``newgidmap``, so you will need to
-  compile/install **shadow-utils** by yourself.
-  
-  Singularity expect to find those binaries in one of those standard paths:
-  ``/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin``
+    $ singularity exec library://alpine cat /etc/alpine-release
+    3.9.2
 
 
-Basics
-======
-
-Fakeroot relies on ``/etc/subuid`` and ``/etc/subgid`` to find the use fakeroot mappings, which
-means that users added in those files could use the fakeroot feature, user mappings must be added
-in files ``/etc/subuid`` and ``/etc/subgid``, here a valid entry for user ``foo``:
-
-For ``/etc/subuid``:
-
-.. code-block:: none
-
-  foo:100000:65536
-
-where ``foo`` is the username, ``100000`` is the start of UID range and ``65536`` the range count.
-
-Same for ``/etc/subgid``:
-
-.. code-block:: none
-
-  foo:100000:65536
-
-where ``foo`` is the username, ``100000`` is the start of GID range and ``65536`` the range count.
-
-.. note::
-
-  Some distributions already adds the main user by default in those files.
-
-.. warning::
-
-  All entries with a range count different from 65536 are not considered valid
-  by Singularity.
-
-  It's also important to ensure that the start range doesn't overlap with existing
-  UID/GID on your system.
-
-So if you want to add another user ``bar``, ``/etc/subuid`` and ``/etc/subgid`` will look like:
-
-.. code-block:: none
-
-  foo:100000:65536
-  bar:165536:65536
-
-Resulting in the following allocation:
-
-+------+----------+----------------------+
-| User | Host UID | UID/GID range        |
-+======+==========+======================+
-| foo  | 1000     | 100000 to 165535     |
-+------+----------+----------------------+
-| bar  | 1001     | 165536 to 231071     |
-+------+----------+----------------------+
-
-It allows unprivileged users to change current UID/GID to any UID/GID between 0 and 65536 inside container.
-It also impacts files and directories ownership depending of UID/GID set in container during file/directory
-creation.
-
-Filesystem consideration
-========================
-
-Based on the above range, here we can see what happens when the user ``foo`` create files with ``--fakeroot``
-feature:
-
-+--------------------------------+----------------------------------+
-| Create file with container UID | Created host file owned by UID   |
-+================================+==================================+
-| 0 (default)                    | 1000                             |
-+--------------------------------+----------------------------------+
-| 1 (daemon)                     | 100000                           |
-+--------------------------------+----------------------------------+
-| 2 (bin)                        | 100001                           |
-+--------------------------------+----------------------------------+
-
-Network consideration
-=====================
-
-With fakeroot, users can request a container network named ``fakeroot``, other networks are restricted and
-can only be used by root user. This network is configured to use a network veth pair, it's strongly advised
-to not change the network type in ``network/40_fakeroot.conflist`` file for security reasons.
-
-.. warning::
-
-  Unprivileged installation could not use ``fakeroot`` network as it requires privileges to setup the network.
-
-.. _updating_singularity:
-
---------------------
-Updating Singularity
---------------------
-
-Updating Singularity is just like installing it, but with the ``--upgrade`` flag
-instead of ``--install``. Make sure you pick the latest tarball from the `Github
-release page <https://github.com/sylabs/singularity/releases>`_.
-
-.. code-block:: none
-
-    $ export VERSION=3.0.2  # the newest singularity version, change as you need
-
-    $ wget https://github.com/sylabs/singularity/releases/download/v${VERSION}/singularity-${VERSION}.tar.gz && \
-        rpmbuild -tb singularity-${VERSION}.tar.gz && \
-        sudo rpm --upgrade -vh ~/rpmbuild/RPMS/x86_64/singularity-${VERSION}-1.el7.x86_64.rpm && \
-        rm -rf ~/rpmbuild singularity-${VERSION}*.tar.gz
-
-.. _uninstalling_singularity:
-
-------------------------
-Uninstalling Singularity
-------------------------
-
-If you install Singularity using RPM, you can uninstall it again in just a one
-command: (Just use ``sudo``, or do this as root)
-
-.. code-block:: none
-
-    $ sudo rpm --erase singularity
+See the `user guide
+<https://www.sylabs.io/guides/\{userversion\}/user-guide/>`__ for more
+information about how to use Singularity.

--- a/conf.py
+++ b/conf.py
@@ -43,7 +43,7 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'Singularity container'
+project = u'Singularity Admin Guide'
 copyright = u'2017-2020, Sylabs Inc'
 
 # The version info for the project you're documenting, acts as replacement for
@@ -322,6 +322,7 @@ epub_exclude_files = []
 sys.path.append(os.path.join(os.path.dirname(__file__), '.'))
 from sphinx.highlighting import lexers
 from pygments_singularity import SingularityLexer
+from replacements import *
 
 # lexer for Singularity definition files (added here until it is upstreamed into Pygments).
 lexers['singularity'] = SingularityLexer(startinline=True)

--- a/index.rst
+++ b/index.rst
@@ -2,9 +2,21 @@
 Admin Guide
 ===========
 
+Welcome to the Singularity Admin Guide!
+
+This guide aims to cover installation instructions, configuration
+detail, and other topics important to system adminstrators working
+with Singularity.
+
+See the `user guide
+<https://www.sylabs.io/guides/\{userversion\}/user-guide/>`__ for more
+information about how to use Singularity.
+
 .. toctree::
-   :maxdepth: 5
+   :maxdepth: 2
 
    Admin Quickstart <admin_quickstart>
+   Installing Singularity <installation>
    Configuration files <configfiles>
+   User Namespaces & Fakeroot <user_namespace>
    Container Security <security>

--- a/installation.rst
+++ b/installation.rst
@@ -1,0 +1,512 @@
+.. _installation:
+
+######################
+Installing Singularity
+######################
+
+This section will guide you through the process of installing
+Singularity {InstallationVersion} via several different methods. (For
+instructions on installing earlier versions of Singularity please see
+`earlier versions of the docs <https://www.sylabs.io/docs/>`_.)
+
+=====================
+Installation on Linux
+=====================
+
+Singularity can be installed on any modern Linux distribution, on
+bare-metal or inside a Virtual Machine. Nested installations inside
+containers are not recommended, and require the outer container to be
+run with full privilege.
+
+-------------------
+System Requirements
+-------------------
+
+Singularity requires ~140MiB disk space once compiled and installed.
+
+There are no specific CPU or memory requirements at runtime, though
+2GB of RAM is recommended when building from source.
+
+Full functionality of Singularity requires that the kernel supports:
+
+ - **OverlayFS mounts** - required for full flexiblity in bind mounts
+   to containers, and to support persistent overlays for writable
+   containers.
+ - **Unprivileged user namespaces** - (minimum kernel >=3.8, >=3.18
+   recommended). Required to run containers without root or setuid
+   privilege.
+
+RHEL & CentOS 6 do not support these features, but Singularity can be
+used with some limitations.
+
+
+Filesystem support
+==================
+
+Singularity supports most filesystems, but there are limitations when
+installing Singularity on, or running containers from common parallel
+/ network filesystems:
+
+ - We strongly recommend installing Singularity on local disk on each
+   compute node.
+ - If Singularity is installed to a network location, a
+   ``--localstatedir`` must be provided on each node, and Singularity
+   configured to use it.
+ - The ``--localstatedir`` filesystem should support overlay mounts.
+ - When running sandbox containers with the ``--fakeroot`` option,
+   filesystem user namespace support is required. User namespace
+   support is known to be incomplete on Lustre, and GPFS.
+
+
+----------------
+Before you begin
+----------------
+
+If you have an earlier version of Singularity installed, you should
+:ref:`remove it <remove-an-old-version>` before executing the
+installation commands.  You will also need to install some
+dependencies and install `Go <https://golang.org/>`_.
+
+.. _install-dependencies:
+
+-------------------
+Install from Source
+-------------------
+
+To use the latest version of Singularity from GitHub you will need to
+build and install it from source. This may sound daunting, but the
+process is straightforward, and detailed below:
+
+
+Install Dependencies
+====================
+
+On Red Hat Enterprise Linux or CentOS install the following dependencies:
+
+.. code-block:: sh
+
+   $ sudo yum update -y && \
+        sudo yum groupinstall -y 'Development Tools' && \
+        sudo yum install -y \
+        openssl-devel \
+        libuuid-devel \
+        libseccomp-devel \
+        wget \
+        squashfs-tools \
+        cryptsetup
+
+        
+On Ubuntu or Debian install the following dependencies:
+
+.. code-block:: sh
+
+    $ sudo apt-get update && sudo apt-get install -y \
+        build-essential \
+        uuid-dev \
+        libgpgme-dev \
+        squashfs-tools \
+        libseccomp-dev \
+        wget \
+        pkg-config \
+        git \
+        cryptsetup-bin
+
+.. note::
+
+   You can build Singularity (3.5+) without ``cryptsetup`` available, but will
+   not be able to use encrypted containers without it installed on your system.
+
+.. _install-go:
+
+Install Go
+==========
+
+Singularity v3 is written primarily in Go, and you will need Go 1.13
+or above installed to compile it from source.
+
+This is one of several ways to `install and configure Go
+<https://golang.org/doc/install>`_.
+
+.. note::
+
+   If you have previously installed Go from a download, rather than an
+   operating system package, you should remove your ``go`` directory,
+   e.g. ``rm -r /usr/local/go`` before installing a newer
+   version. Extracting a new version of Go over an existing
+   installation can lead to errors when building Go programs, as it
+   may leave old files, which have been removed or replaced in newer
+   versions.
+
+
+Visit the `Go download page <https://golang.org/dl/>`_ and pick a package
+archive to download. Copy the link address and download with wget.  Then extract
+the archive to ``/usr/local`` (or use other instructions on go installation
+page).
+
+.. code-block:: none
+
+    $ export VERSION=1.13.5 OS=linux ARCH=amd64 && \
+        wget https://dl.google.com/go/go$VERSION.$OS-$ARCH.tar.gz && \
+        sudo tar -C /usr/local -xzvf go$VERSION.$OS-$ARCH.tar.gz && \
+        rm go$VERSION.$OS-$ARCH.tar.gz
+
+Then, set up your environment for Go.
+
+.. code-block:: none
+
+    $ echo 'export GOPATH=${HOME}/go' >> ~/.bashrc && \
+        echo 'export PATH=/usr/local/go/bin:${PATH}:${GOPATH}/bin' >> ~/.bashrc && \
+        source ~/.bashrc
+
+Download Singularity from a release
+===================================
+
+You can download Singularity from one of the releases. To see a full
+list, visit `the GitHub release page
+<https://github.com/sylabs/singularity/releases>`_.  After deciding on
+a release to install, you can run the following commands to proceed
+with the installation.
+
+.. code-block:: none
+
+    $ export VERSION={InstallationVersion} && # adjust this as necessary \
+        wget https://github.com/sylabs/singularity/releases/download/v${VERSION}/singularity-${VERSION}.tar.gz && \
+        tar -xzf singularity-${VERSION}.tar.gz && \
+        cd singularity
+
+Checkout Code from Git
+======================
+
+The following commands will install Singularity from the `GitHub repo
+<https://github.com/sylabs/singularity>`_ to ``/usr/local``. This
+method will work for >=v{InstallationVersion}. To install an older
+tagged release see `older versions of the docs
+<https://www.sylabs.io/docs/>`_.
+
+When installing from source, you can decide to install from either a
+**tag**, a **release branch**, or from the **master branch**.
+
+- **tag**: GitHub tags form the basis for releases, so installing from
+  a tag is the same as downloading and installing a `specific release
+  <https://github.com/sylabs/singularity/releases>`_.  Tags are
+  expected to be relatively stable and well-tested.
+
+- **release branch**: A release branch represents the latest version
+  of a minor release with all the newest bug fixes and enhancements
+  (even those that have not yet made it into a point release).  For
+  instance, to install v3.2 with the latest bug fixes and enhancements
+  checkout ``release-3.2``.  Release branches may be less stable than
+  code in a tagged point release.
+
+- **master branch**: The ``master`` branch contains the latest,
+  bleeding edge version of Singularity. This is the default branch
+  when you clone the source code, so you don't have to check out any
+  new branches to install it. The ``master`` branch changes quickly
+  and may be unstable.
+
+To ensure that the Singularity source code is downloaded to the
+appropriate directory use these commands.
+
+.. code-block:: none
+
+    $ git clone https://github.com/sylabs/singularity.git && \
+        cd singularity && \
+        git checkout v{InstallationVersion}
+
+Compile Singularity
+===================
+
+Singularity uses a custom build system called ``makeit``.  ``mconfig``
+is called to generate a ``Makefile`` and then ``make`` is used to
+compile and install.
+
+To support the SIF image format, automated networking setup etc., and
+older Linux distributions without user namespace support, Singularity
+must be ``make install``ed as root or with ``sudo``, so it can install
+the ``libexec/singularity/bin/starter-setuid`` binary with root
+ownership and setuid permissions for privileged operations. If you
+need to install as a normal user, or do not want to use setuid
+functionality :ref:`see below <install-nonsetuid>`.
+
+.. code-block:: none
+
+    $ ./mconfig && \
+        make -C ./builddir && \
+        sudo make -C ./builddir install
+
+By default Singularity will be installed in the ``/usr/local``
+directory hierarchy. You can specify a custom directory with the
+``--prefix`` option, to ``mconfig`` like so:
+
+.. code-block:: none
+
+    $ ./mconfig --prefix=/opt/singularity
+
+This option can be useful if you want to install multiple versions of
+Singularity, install a personal version of Singularity on a shared
+system, or if you want to remove Singularity easily after installing
+it.
+
+For a full list of ``mconfig`` options, run ``mconfig --help``.  Here
+are some of the most common options that you may need to use when
+building Singularity from source.
+
+- ``--sysconfdir``: Install read-only config files in sysconfdir.
+  This option is important if you need the ``singularity.conf`` file
+  or other configuration files in a custom location.
+
+- ``--localstatedir``: Set the state directory where containers are
+  mounted. This is a particularly important option for administrators
+  installing Singularity on a shared file system.  The
+  ``--localstatedir`` should be set to a directory that is present on
+  each individual node.
+
+- ``-b``: Build Singularity in a given directory. By default this is
+  ``./builddir``.
+
+.. _install-nonsetuid:
+
+
+Unprivileged (non-setuid) Installation
+======================================
+
+If you need to install Singularity as a non-root user, or do not wish
+to allow the use of a setuid root binary, you can configure
+singularity with the ``--without-setuid`` option to mconfig:
+
+.. code-block:: none
+
+    $ ./mconfig --without-setuid --prefix=/home/dave/singularity && \
+        make -C ./builddir && \
+        make -C ./builddir install
+
+If you have already installed Singularity you can disable the setuid
+flow by setting the option ``allow setuid = no`` in
+``etc/singularity/singularity.conf`` within your installation
+directory.
+
+When singularity does not use setuid all container execution will use
+a user namespace. This requires support from your operating system
+kernel, and imposes some limitations on functionality. You should
+review the :ref:`requirements <userns-requirements>` and
+:ref:`limitations <userns-limitations>` in the :ref:`user namespace
+<userns>` section of this guide.
+
+  
+Source bash completion file
+===========================
+
+To enjoy bash shell completion with Singularity commands and options,
+source the bash completion file:
+
+.. code-block:: none
+
+    $ . /usr/local/etc/bash_completion.d/singularity
+
+Add this command to your `~/.bashrc` file so that bash completion
+continues to work in new shells.  (Adjust the path if you
+installed Singularity to a different location.)
+
+.. _install-rpm:
+
+------------------------
+Build and install an RPM
+------------------------
+
+If you use RHEL, CentOS or SUSE, building and installing a Singularity
+RPM allows your Singularity installation be more easily managed,
+upgraded and removed. In Singularity >=v3.0.1 you can build an RPM
+directly from the `release tarball
+<https://github.com/sylabs/singularity/releases>`_.
+
+.. note::
+
+    Be sure to download the correct asset from the `GitHub releases
+    page <https://github.com/sylabs/singularity/releases>`_.  It
+    should be named `singularity-<version>.tar.gz`.
+
+After installing the :ref:`dependencies <install-dependencies>` and
+installing :ref:`Go <install-go>` as detailed above, you are ready to
+download the tarball and build and install the RPM.
+
+.. code-block:: none
+
+    $ export VERSION={InstallationVersion} && # adjust this as necessary \
+        wget https://github.com/sylabs/singularity/releases/download/v${VERSION}/singularity-${VERSION}.tar.gz && \
+        rpmbuild -tb singularity-${VERSION}.tar.gz && \
+        sudo rpm -ivh ~/rpmbuild/RPMS/x86_64/singularity-$VERSION-1.el7.x86_64.rpm && \
+        rm -rf ~/rpmbuild singularity-$VERSION*.tar.gz
+
+If you encounter a failed dependency error for golang but installed it
+from source, build with this command:
+
+.. code-block:: none
+
+    rpmbuild -tb --nodeps singularity-${VERSION}.tar.gz
+
+
+Options to ``mconfig`` can be passed using the familiar syntax to
+``rpmbuild``.  For example, if you want to force the local state
+directory to ``/mnt`` (instead of the default ``/var``) you can do the
+following:
+
+.. code-block:: none
+
+    rpmbuild -tb --define='_localstatedir /mnt' singularity-$VERSION.tar.gz
+
+.. note::
+
+     It is very important to set the local state directory to a
+     directory that physically exists on nodes within a cluster when
+     installing Singularity in an HPC environment with a shared file
+     system. 
+
+.. _remove-an-old-version:
+
+---------------------
+Remove an old version
+---------------------
+
+In a standard installation of Singularity 3.0.1 and beyond (when
+building from source), the command ``sudo make install`` lists all the
+files as they are installed. You must remove all of these files and
+directories to completely remove Singularity.
+
+.. code-block:: none
+
+    $ sudo rm -rf \
+        /usr/local/libexec/singularity \
+        /usr/local/var/singularity \
+        /usr/local/etc/singularity \
+        /usr/local/bin/singularity \
+        /usr/local/bin/run-singularity \
+        /usr/local/etc/bash_completion.d/singularity
+
+If you anticipate needing to remove Singularity, it might be easier to
+install it in a custom directory using the ``--prefix`` option to
+``mconfig``.  In that case Singularity can be uninstalled simply by
+deleting the parent directory. Or it may be useful to install
+Singularity :ref:`using a package manager <install-rpm>` so that it
+can be updated and/or uninstalled with ease in the future.
+
+------------------------------------
+Distribution packages of Singularity
+------------------------------------
+
+.. note::
+
+    Packaged versions of Singularity in Linux distribution repos are
+    maintained by community members. They may be older releases of
+    Singularity, as it can take time to package and distribute new
+    versions. For the latest upstream versions of Singularity it is
+    recommended that you build from source using one of the methods
+    detailed above.
+
+Install the CentOS/RHEL package using yum
+=========================================
+
+The EPEL (Extra Packages for Enterprise Linux) repos contain
+Singularity rpms that are regularly updated. To install Singularity
+from the epel repos, first install the epel-release package and then
+install Singularity.  For instance, on CentOS 6/7/8 do the following:
+
+.. code-block:: none
+
+    $ sudo yum update -y && \
+        sudo yum install -y epel-release && \
+        sudo yum update -y && \
+        sudo yum install -y singularity
+
+==============================
+Installation on Windows or Mac
+==============================
+
+Linux container runtimes like Singularity cannot run natively on
+Windows or Mac because of basic incompatibilities with the host
+kernel. (Contrary to a popular misconception, MacOS does not run on a
+Linux kernel. It runs on a kernel called Darwin originally forked
+from BSD.)
+
+For this reason, the Singularity community maintains a set of Vagrant
+Boxes via `Vagrant Cloud <https://www.vagrantup.com/>`__, one of
+`Hashicorp's <https://www.hashicorp.com/#open-source-tools>`_ open
+source tools. The current versions can be found under the `sylabs
+<https://app.vagrantup.com/sylabs>`_ organization.
+
+Sylabs has also developed a beta version of Singularity Desktop for
+Mac, which runs Singularity in a lightweight virtual machine, in a
+transparent manner.
+
+-------
+Windows
+-------
+
+Install the following programs:
+
+ -  `Git for Windows <https://git-for-windows.github.io/>`_
+ -  `VirtualBox for Windows <https://www.virtualbox.org/wiki/Downloads>`_
+ -  `Vagrant for Windows <https://www.vagrantup.com/downloads.html>`_
+ -  `Vagrant Manager for Windows <http://vagrantmanager.com/downloads/>`_
+
+---
+Mac
+---
+
+To use Singularity Desktop for macOS (Beta Preview):
+
+Download a Mac installer package `here
+<https://www.sylabs.io/singularity-desktop-macos/>`__.
+
+Singularity is also available via Vagrant (installable with
+`Homebrew <https://brew.sh>`_ or manually) or with the Singularity Desktop for
+macOS (Alpha Preview).
+
+To use Vagrant via Homebrew:
+
+.. code-block:: none
+
+    $ /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+    $ brew cask install virtualbox && \
+        brew cask install vagrant && \
+        brew cask install vagrant-manager
+
+-----------------------        
+Singularity Vagrant Box
+-----------------------
+
+Run Git Bash (Windows) or open a terminal (Mac) and create and enter a
+directory to be used with your Vagrant VM.
+
+.. code-block:: none
+
+    $ mkdir vm-singularity && \
+        cd vm-singularity
+
+If you have already created and used this folder for another VM, you will need
+to destroy the VM and delete the Vagrantfile.
+
+.. code-block:: none
+
+    $ vagrant destroy && \
+        rm Vagrantfile
+
+Then issue the following commands to bring up the Virtual Machine. (Substitute a
+different value for the ``$VM`` variable if you like.)
+
+.. code-block:: none
+
+    $ export VM=sylabs/singularity-3.5-ubuntu-bionic64 && \
+        vagrant init $VM && \
+        vagrant up && \
+        vagrant ssh
+
+You can check the installed version of Singularity with the following:
+
+.. code-block:: none
+
+    vagrant@vagrant:~$ singularity version
+    3.5.2
+
+
+Of course, you can also start with a plain OS Vagrant box as a base and then
+install Singularity using one of the above methods for Linux.

--- a/installation.rst
+++ b/installation.rst
@@ -29,11 +29,11 @@ There are no specific CPU or memory requirements at runtime, though
 
 Full functionality of Singularity requires that the kernel supports:
 
- - **OverlayFS mounts** - required for full flexiblity in bind mounts
-   to containers, and to support persistent overlays for writable
-   containers.
+ - **OverlayFS mounts** - (minimum kernel >=3.18) Required for full
+   flexiblity in bind mounts to containers, and to support persistent
+   overlays for writable containers.
  - **Unprivileged user namespaces** - (minimum kernel >=3.8, >=3.18
-   recommended). Required to run containers without root or setuid
+   recommended) Required to run containers without root or setuid
    privilege.
 
 RHEL & CentOS 6 do not support these features, but Singularity can be

--- a/security.rst
+++ b/security.rst
@@ -41,7 +41,7 @@ important component of SIF that elicits security feature is the ability to crypt
 block within the SIF file which can guarantee immutability and provide accountability as to who signed it. Singularity follows the 
 `OpenPGP <https://www.openpgp.org/>`_ standard to create and manage these keys. After building an image within Singularity, users can
 ``singularity sign`` the container and push it to the Library along with its public PGP key(Stored in :ref:`Keystore <keystore>`) which 
-later can be verified (``singularity verify``) while pulling or downloading the image. :ref:`This feature <signNverify>` in particular 
+later can be verified (``singularity verify``) while pulling or downloading the image. This feature in particular 
 protects collaboration within and between systems and teams. 
 
 With a new development to SIF, the root file system that resides in the squashFS partition of SIF can be encrypted, rendering it's contents

--- a/user_namespace.rst
+++ b/user_namespace.rst
@@ -202,7 +202,8 @@ Resulting in the following allocation:
 
 Inside a user namespace / container, ``foo`` and ``bar`` can now act
 as any UID/GID between 0 and 65536, but these UIDs are confined to the
-container. For ``foo`` UID 0 in the container will map to ``100000``
+container. For ``foo`` UID 0 in the container will map to the host
+``foo`` UID ``1000`` and ``1 to 65535`` will map to ``100000-165535``
 outside of the container etc. This impacts the ownership of files,
 which will have different IDs inside and outside of the container.
 

--- a/user_namespace.rst
+++ b/user_namespace.rst
@@ -204,7 +204,7 @@ Resulting in the following allocation:
 Inside a user namespace / container, ``foo`` and ``bar`` can now act
 as any UID/GID between 0 and 65536, but these UIDs are confined to the
 container. For ``foo`` UID 0 in the container will map to the host
-``foo`` UID ``1000`` and ``1 to 65535`` will map to ``100000-165535``
+``foo`` UID ``1000`` and ``1 to 65536`` will map to ``100000-165535``
 outside of the container etc. This impacts the ownership of files,
 which will have different IDs inside and outside of the container.
 

--- a/user_namespace.rst
+++ b/user_namespace.rst
@@ -1,0 +1,252 @@
+.. _userns:
+
+==========================
+User Namespaces & Fakeroot
+==========================
+
+User namespaces are an isolation feature that allow processes to run
+with different user identifiers and/or privileges inside that
+namespace than are permitted outside. A user may have a ``uid`` of
+``1001`` on a system outside of a user namespace, but run programs
+with a different ``uid`` with different privileges inside the
+namespace.
+
+User namespaces are used with containers to make it possible to setup
+a container without privileged operations, and so that a normal user
+can act as root inside a container to perform administrative tasks,
+without being root on the host outside.
+
+
+Singularity uses user namespaces in 3 situations:
+
+ - When the ``setuid`` workflow is disabled or Singularity was
+   installed without root.
+ - When a container is run with the ``--userns`` option.
+ - When ``--fakeroot`` is used to impersonate a root user when
+   building or running a container.
+
+.. _userns-requirements:
+   
+---------------------------
+User Namespace Requirements
+---------------------------
+
+To allow unprivileged creation of user namespaces a kernel >=3.8 is
+required, with >=3.18 being recommended as it adds OverlayFS support.
+
+Additionally, some Linux distributions require that unprivileged user
+namespace creation is enabled using a ``sysctl`` or kernel command
+line parameter. Please consult your distribution documentation or
+vendor to confirm the steps necessary to 'enable unprivileged user
+namespace creation'.
+
+Debian
+======
+
+.. code-block:: none
+
+  sudo sysctl -w kernel.unprivileged_userns_clone=1
+
+RHEL/CentOS 7
+=============
+
+From 7.4, kernel support is included but must be enabled with:
+
+.. code-block:: none
+
+  echo 10000 > /proc/sys/user/max_user_namespaces
+
+
+.. _userns-limitations:
+  
+--------------------------
+Unprivileged Installations  
+--------------------------
+
+As detailed in the :ref:`non-setuid installation <install-nonsetuid>`
+section, Singularity can be compiled or configured with the ``allow
+setuid = no`` option in ``singularity.conf`` to not perform privileged
+operations using the ``starter-setuid`` binary.
+
+When singularity does not use ``setuid`` all container execution will
+use a user namespace. In this mode of operation, some features are not
+available, and there are impacts to the security/integrity guarantees
+when running SIF container images:
+
+ - All containers must be run from sandbox directories. SIF images are
+   extracted to a sandbox directory on the fly, preventing
+   verification at runtime, and potentially allowing external
+   modification of the container at runtime.
+ - Filesystem image, and SIF-embedded persistent overlays cannot be
+   used.
+ - Encrypted containers cannot be used. Singularity mounts encrypted
+   containers directly through the kernel, so that encrypted content
+   is not extracted to disk. This requires the setuid workflow.
+ - Fakeroot functionality will rely on external setuid root
+   ``newuidmap`` and ``newgidmap`` binaries which may be provided by
+   the distribution.
+
+---------------
+--userns option
+---------------
+
+The ``--userns`` option to `singularity run/exec/shell` will start a
+container using a user namespace, avoiding the setuid privileged
+workflow for container setup even if Singularity was compiled and
+configured to use setuid by default.
+
+The same limitations apply as in an unprivileged installation.
+
+.. _fakeroot:
+
+----------------
+Fakeroot feature
+----------------
+
+Fakeroot (or commonly referred as rootless mode) allows an
+unprivileged user to run a container as a **"fake root"** user by
+leveraging user namespaces with `user namespace UID/GID mapping
+<http://man7.org/linux/man-pages/man7/user_namespaces.7.html>`_.
+
+User namespace UID/GID mapping allows a user to act as a different
+UID/GID in the container than they are on the host. A user can access
+a configured range of UIDs/GIDs in the container, which map back to
+(generally) unprivileged user UIDs/GIDs on the host. This allows a
+user to be ``root (uid 0)`` in a container, install packages etc., but
+have no privilege on the host.
+
+Requirements
+============
+
+In addition to user namespace support, Singularity must manipulate
+``subuid`` and ``subgid`` maps for the user namepsace it creates. By
+default this happens transparently in the setuid workflow. With
+unprivileged installations of Singularity or where ``allow setuid =
+no`` is set in ``singularity.conf``, Singularity attempts to use
+external setuid binaries ``newuidmap`` and ``newgidmap``, so you
+need to install those binaries on your system.
+
+.. note::
+
+  CentOS/RHEL 7 doesn't provide a package for ``newuidmap`` and
+  ``newgidmap``, so you will need to compile/install **shadow-utils**
+  by yourself.
+  
+  Singularity expects to find these binaries in one of those standard
+  paths:
+  ``/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin``
+
+
+Basics
+======
+
+Fakeroot relies on ``/etc/subuid`` and ``/etc/subgid`` files to find
+configured mappings from real user and group IDs, to a range of
+otherwise vacant IDs for each user on the host system that can be
+remapped in the usernamespace. A user must have an entry in these
+system configuration files to use the fakeroot feature.
+
+For user ``foo`` an entry in ``/etc/subuid`` might be:
+
+.. code-block:: none
+
+  foo:100000:65536
+
+where ``foo`` is the username, ``100000`` is the start of the UID
+range that can be used by ``foo`` in a user namespace uid mapping, and
+``65536`` number of UIDs available for mapping.
+
+Same for ``/etc/subgid``:
+
+.. code-block:: none
+
+  foo:100000:65536
+
+.. note::
+
+  Some distributions add users to these files on installation, or when
+  ``useradd``, ``adduser``, etc. utilities are used to manage local
+  users.
+
+  The glibc nss name service switch mechanism does not currently
+  support managing ``subuid`` and ``subgid`` mappings with external
+  directory services such as LDAP. You must manage or provision
+  mapping files direct to systems where fakeroot will be used.
+
+.. warning::
+
+  Singularity requires that a range of at least ``65536`` IDs is used
+  for each mapping. Larger ranges may be defined without error.
+
+  It is also important to ensure that the subuid and subgid ranges
+  defined in these files don't overlap with any real UIDs and GIDs on
+  the host system.
+
+So if you want to add another user ``bar``, ``/etc/subuid`` and
+``/etc/subgid`` will look like:
+
+.. code-block:: none
+
+  foo:100000:65536
+  bar:165536:65536
+
+Resulting in the following allocation:
+
++------+----------+----------------------+
+| User | Host UID | Sub UID/GID range    |
++======+==========+======================+
+| foo  | 1000     | 100000 to 165535     |
++------+----------+----------------------+
+| bar  | 1001     | 165536 to 231071     |
++------+----------+----------------------+
+
+Inside a user namespace / container, ``foo`` and ``bar`` can now act
+as any UID/GID between 0 and 65536, but these UIDs are confined to the
+container. For ``foo`` UID 0 in the container will map to ``100000``
+outside of the container etc. This impacts the ownership of files,
+which will have different IDs inside and outside of the container.
+
+
+Filesystem consideration
+========================
+
+Based on the above range, here we can see what happens when the user
+``foo`` create files with ``--fakeroot`` feature:
+
++--------------------------------+----------------------------------+
+| Create file with container UID | Created host file owned by UID   |
++================================+==================================+
+| 0 (default)                    | 1000                             |
++--------------------------------+----------------------------------+
+| 1 (daemon)                     | 100000                           |
++--------------------------------+----------------------------------+
+| 2 (bin)                        | 100001                           |
++--------------------------------+----------------------------------+
+
+Outside of the fakeroot container the user may not be able to remove
+directories and files created with a subuid, as they do not match with
+the user's UID on the host. The user can remove these files by using a
+container shell running with fakeroot.
+
+
+Network configurations
+======================
+
+With fakeroot, users can request a container network named
+``fakeroot``, other networks are restricted and can only be used by
+the real host root user. By default the ``fakeroot`` network is
+configured to use a network veth pair.
+
+.. warning::
+
+   Do not change the ``fakeroot`` network type in
+   ``etc/singularity/network/40_fakeroot.conflist`` without
+   considering the security implications.
+
+.. note::
+
+  Unprivileged installations of Singularity cannot use ``fakeroot``
+  network as it requires privilege during container creation to setup
+  the network.
+
+.. _updating_singularity:

--- a/user_namespace.rst
+++ b/user_namespace.rst
@@ -32,7 +32,8 @@ User Namespace Requirements
 ---------------------------
 
 To allow unprivileged creation of user namespaces a kernel >=3.8 is
-required, with >=3.18 being recommended as it adds OverlayFS support.
+required, with >=3.18 being recommended due to security fixes for user
+namespaces (3.18 also adds OverlayFS support which is used by Singularity).
 
 Additionally, some Linux distributions require that unprivileged user
 namespace creation is enabled using a ``sysctl`` or kernel command


### PR DESCRIPTION
 - Slim down the quick start content, focus on source install like in
   the userdocs... on OSS I think rpm from source is not going to be the
   most common method.
 - Add a installation section to bring across various methods of
   installation from the userdocs.
 - Add a user namespace / fakeroot section. Describe userns requirements
   / limitations here and reference elsewhere. Move fakeroot content
   here.