### PR TITLE
CI Improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ executors:
       - image: node:16-slim
   python:
     docker:
-      - image: python:3.6-buster
+      - image: python:3.9-buster
 
 jobs:
   lint_markdown:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   node:
     docker:
-      - image: node:11-slim
+      - image: node:16-slim
   python:
     docker:
       - image: python:3.6-buster

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,15 +1,16 @@
 version: 2.1
 
-defaults: &defaults
-  docker:
-    - image: python:3.6-buster
-
-jobs:
-
-  lint_markdown:
-    <<: *defaults
+executors:
+  node:
     docker:
       - image: node:11-slim
+  python:
+    docker:
+      - image: python:3.6-buster
+
+jobs:
+  lint_markdown:
+    executor: node
     steps:
       - checkout
       - run:
@@ -20,7 +21,7 @@ jobs:
           command: markdownlint .
 
   check_rst:
-    <<: *defaults
+    executor: python
     steps:
       - checkout
       - run:
@@ -33,7 +34,7 @@ jobs:
             rstcheck --report warning *.rst
 
   make_html:
-    <<: *defaults
+    executor: python
     steps:
       - checkout
       - run:
@@ -53,7 +54,7 @@ jobs:
           destination: html
 
   make_pdf_epub:
-    <<: *defaults
+    executor: python
     steps:
       - checkout
       - run:
@@ -92,4 +93,3 @@ workflows:
       - make_pdf_epub:
           requires:
             - check_rst
-


### PR DESCRIPTION
Use [reusable executors](https://circleci.com/docs/2.0/reusing-config/#authoring-reusable-executors) instead of YAML anchors in CircleCI config. Bump `node` from 11.x to 16.x, and `python` from 3.6 to 3.9.