### PR TITLE
Replace security information with rewritten content

### DIFF
--- a/admin_quickstart.rst
+++ b/admin_quickstart.rst
@@ -42,6 +42,11 @@ namespaces and other security and resource limits to accomplish this.
  {Singularity} Security
 ************************
 
+.. note::
+
+   See also the :ref:`security section <security>` of this guide, for more
+   detail.
+
 {Singularity} uses a number of strategies to provide safety and
 ease-of-use on both single-user and shared systems. Notable security
 features include:

--- a/configfiles.rst
+++ b/configfiles.rst
@@ -485,6 +485,9 @@ Above we can see that ``/etc/resolv.conf`` is listed as a bind path in
 the output of the ``--dry-run`` command, but did not affect the actual
 bind paths of the system.
 
+
+.. _cgroups_toml:
+
 **************
  cgroups.toml
 **************

--- a/index.rst
+++ b/index.rst
@@ -19,7 +19,7 @@ information about how to use {Singularity}.
    Installing {Singularity} <installation>
    Configuration files <configfiles>
    User Namespaces & Fakeroot <user_namespace>
-   Container Security <security>
+   Security in {Singularity} <security>
 
    Appendix <appendix>
    License <license>

--- a/security.rst
+++ b/security.rst
@@ -1,264 +1,196 @@
 .. _security:
 
-######################################
- Security in {Singularity} Containers
-######################################
+###########################
+ Security in {Singularity}
+###########################
 
-Containers are all the rage today for many good reasons. They are
-lightweight, easy to spin-up and require reduced IT management resources
-as compared to hardware VM environments. More importantly, container
-technology facilitates advanced research computing by granting the
-ability to package software in highly portable and reproducible
-environments encapsulating all dependencies, including the operating
-system. But there are still some challenges to container security.
+*****************
+ Security Policy
+*****************
 
-Singularity, which is a container paradigm created by necessity for
-scientific and application driven workloads, addresses some core
-missions of containers : Mobility of Compute, Reproducibility, HPC
-support, and **Security**. This document intends to inform admins of
-different security features supported by {Singularity}.
+If you suspect you have found a vulnerability in {Singularity} we want
+to work with you so that it can be investigated, fixed, and disclosed in
+a responsible manner. Please follow the steps in our published `Security
+Policy <https://sylabs.io/security-policy>`__, which begins with
+contacting us privately via security@sylabs.io
 
-***********************
- {Singularity} Runtime
-***********************
+Sylabs discloses vulnerabilities found in {Singularity} through public
+CVE reports, and notifications on our community channels. We encourage
+all users to monitor new releases of {Singularity} for security
+information. Security patches are applied to the latest open-source
+release.
 
-The {Singularity} runtime enforces a unique security model that makes it
-appropriate for *untrusted users* to run *untrusted containers* safely
-on multi-tenant resources. Because the {Singularity} runtime dynamically
-writes UID and GID information to the appropriate files within the
-container, the user remains the same *inside* and *outside* the
-container, i.e., if you're an unprivileged user while entering the
-container, you'll remain an unprivileged user inside the container. A
-privilege separation model is in place to prevent users from escalating
-privileges once they are inside of a container. The container file
-system is mounted using the ``nosuid`` option, and processes are spawned
-with the ``PR_NO_NEW_PRIVS`` flag. Taken together, this approach
-provides a secure way for users to run containers and greatly simplifies
-things like reading and writing data to the host system with appropriate
-ownership.
+SingularityPRO is a professionally curated and licensed version of
+{Singularity} that provides added security, stability, and support
+beyond that offered by the open source project. Security and bug-fix
+patches are backported to select versions of SingularityPRO, so that
+they can be deployed long-term where required. PRO users receive
+security fixes as detailed in the `Sylabs Security Policy
+<https://sylabs.io/security-policy>`__.
 
-It is also important to note that the philosophy of {Singularity} is
-*Integration* over *Isolation*. Most container runtimes strive to
-isolate your container from the host system and other containers as much
-as possible. {Singularity}, on the other hand, assumes that the user’s
-primary goals are portability, reproducibility, and ease of use and that
-isolation is often a tertiary concern. Therefore, {Singularity} only
-isolates the mount namespace by default, and will also bind mount
-several host directories such as ``$HOME`` and ``/tmp`` into the
-container at runtime. If needed, additional levels of isolation can be
-achieved by passing options causing {Singularity} to enter any or all of
-the other kernel namespaces and to prevent automatic bind mounting.
-These measures allow users to interact with the host system from within
-the container in sensible ways.
+************
+ Background
+************
+
+{Singularity} grew out of the need to implement a container platform
+that was suitable for use on shared systems, such as HPC clusters. In
+these environments multiple people access a shared resource. User
+accounts, groups, and standard file permissions limit their access to
+data, devices, and prevent them from disrupting or accessing others'
+work.
+
+To provide security in these environments a container needs to run as
+the user who starts it on the system. Before the widespread adoption of
+the Linux user namespace, only a privileged user could perform the
+operations which are needed to run a container. A default Docker
+installation uses a root-owned daemon to start containers. Users can
+request that the daemon starts a container on their behalf. However,
+coordinating a daemon with other schedulers is difficult and, since the
+daemon is privileged, users can ask it to carry out actions that they
+wouldn't normally have permission to do.
+
+When a user runs a container with {Singularity}, it is started as a
+normal process running under the user's account. Standard file
+permissions and other security controls based on user accounts, groups,
+and processes apply. In a default installation {Singularity} uses a
+setuid starter binary to perform only the specific tasks needed to setup
+the container.
+
+**************************
+ Setuid & User Namespaces
+**************************
+
+Using a setuid binary to run container setup operations is essential to
+support containers on older Linux distributions, such as CentOS 6, that
+were previously common in HPC and enterprise. Newer distributions have
+support for 'unprivileged user namespace creation'. This means a normal
+user can create a user namespace, in which most setup operations needed
+to run a container can be run, unprivileged.
+
+{Singularity} supports running containers without setuid, using user
+namespaces. It can be compiled with the ``--without-setuid`` option, or
+``allow setuid = no`` can be set in ``singularity.conf`` to enable this.
+In this mode *all* operations run as the user who starts the
+``singularity`` program. However, there are some disadvantages:
+
+-  SIF and other single file container images cannot be mounted
+   directly. The container image must be extracted to a directory on
+   disk to run. This impact the speed of execution. Workloads accessing
+   large numbers of small files (such as python application startup) do
+   not benefit from the reduced metadata load on the filesystem an image
+   file provides.
+
+-  Replacing direct kernel mounts with a FUSE approach is likely to
+   cause a significant reduction in perfomance.
+
+-  The effectiveness of signing and verifying container images is
+   reduced as, when extracted to a directory, modification is possible
+   and verification of the image's original signature cannot be
+   performed.
+
+-  Encryption is not supported. {Singularity} leverages kernel LUKS2
+   mounts to run encrypted containers without decrypting their content
+   to disk.
+
+-  Some sites hold the opinion that vulnerabilities in kernel user
+   namespace code could have greater impact than vulnerabilities
+   confined to a single piece of setuid software. Therefore they are
+   reluctant to enable unprivileged user namespace creation.
+
+Because of the points above, the default mode of operation of
+{Singularity} uses a setuid binary. Sylabs aims to reduce the
+circumstances that require this as new functionality is developed and
+reaches commonly deployed Linux distributions.
+
+********************************
+ Runtime & User Privilege Model
+********************************
+
+While other runtimes have aimed to safely sandbox containers executing
+as the ``root`` user, so that they cannot affect the host system,
+{Singularity} has adopted an alternative security model:
+
+-  Containers should be run as an unprivileged user.
+
+-  The user should never be able to elevate their privileges inside the
+   container to gain control over the host.
+
+-  All permission restrictions on the user outside of a container should
+   apply inside the container.
+
+-  Favor integration over isolation. Allow a user to use host resources
+   such as GPUs, network file systems, high speed interconnects easily.
+   The process ID space, network etc. are not isolated in separate
+   namespaces by default.
+
+To accomplish this, {Singularity} uses a number of Linux kernel
+features. The container file system is mounted using the ``nosuid``
+option, and processes are started with the ``PR_NO_NEW_PRIVS`` flag set.
+This means that even if you run ``sudo`` inside your container, you
+won't be able to change to another user, or gain root privileges by
+other means.
+
+If you do require the additional isolation of the network, devices, PIDs
+etc. provided by other runtimes, {Singularity} can make use of
+additional namespaces and functionality such as seccomp and cgroups.
 
 ********************************
  Singularity Image Format (SIF)
 ********************************
 
-Sylabs addresses container security as a continuous process. It attempts
-to provide container integrity throughout the distribution pipeline..
-i.e., at rest, in transit and while running. Hence, the SIF has been
-designed to achieve these goals.
+{Singularity} uses SIF as its default container format. A SIF container
+is a single file, which makes it easy to manage and distribute. Inside
+the SIF file, the container filesystem is held in a SquashFS object. By
+default, we mount the container filesystem directly using SquashFS. On a
+network filesystem this means that reads from the container are
+data-only. Metadata operations happen locally, speeding up workloads
+with many small files.
 
-A SIF file is an immutable container runtime image. It is a physical
-representation of the container environment itself. An important
-component of SIF that elicits security feature is the ability to
-cryptographically sign a container, creating a signature block within
-the SIF file which can guarantee immutability and provide accountability
-as to who signed it. {Singularity} follows the `OpenPGP
-<https://www.openpgp.org/>`_ standard to create and manage these keys.
-After building an image within {Singularity}, users can ``singularity
-sign`` the container and push it to the Library along with its public
-PGP key(Stored in :ref:`Keystore <keystore>`) which later can be
-verified (``singularity verify``) while pulling or downloading the
-image. This feature in particular protects collaboration within and
-between systems and teams.
+Holding the container image in a single file also enable unique security
+features. The container filesystem is immutable, and can be signed. The
+signature travels in the SIF image itself so that it is always possible
+to verify that the image has not been tampered with or corrupted.
 
-SIF Encryption
-==============
+We use private PGP keys to create a container signature, and the public
+key in order to verify the container. Verification of signed containers
+happens automatically in ``singularity pull`` commands against the
+Sylabs Cloud Container Library. A Keystore in the Sylabs Cloud makes it
+easier to share and obtain public keys for container verification.
 
-In {Singularity} 3.4 and above the container root filesystem that
-resides in the squashFS partition of a SIF can be encrypted, rendering
-it's contents inaccessible without a secret. Unlike other platforms,
-where encrypted layers must be assembled into an unencrypted runtime
-directory on disk, {Singularity} mounts the encrypted root file system
-directly from the SIF using Kernel dm-crypt/LUKS functionality, so that
-the content is not exposed on disk. {Singularity} containers provide a
-comparable level of security to LUKS2 full disk encryption commonly
-deployed on Linux server and desktop systems.
+A container may be signed once, by a trusted individual who approves its
+use. It could also be signed with multiple keys to signify it has passed
+each step in a CI/CD QA & Security process. {Singularity} can be
+configured with an execution control list (ECL), which requires the
+presence of one or more valid signatures, to limit execution to approved
+containers.
 
-As with all matters of security, a layered approach must be taken and
-the system as a whole considered. For example, it is possible that
-decrypted memory pages could be paged out the system swap file or
-device, which could result in decrypted information being stored at rest
-on physical media. Operating system level mitigations such as encrypted
-swap space may be required depending on the needs of your application.
+In {Singularity} 3.4 and above, the root filesystem of a container
+(stored in the squashFS partition of SIF) can be encrypted. As a result,
+everything inside the container becomes inaccessible without the correct
+key or passphrase. The content of the container is private, even if the
+SIF file is shared in public.
 
-Encryption and decryption of containers requires ``cryptsetup`` version
-2. The SIF root filesystem will be encrypted using the default LUKS
-cipher on the host. The current default cipher used by ``cryptsetup``
-for LUKS2 in mainstream Linux distributions is ``aes-xts-plain64`` with
-a 256 bit key size. The default key derivation function for LUKS2 is
-``argon2i``.
+Encryption and decryption are performed using the Linux kernel's LUKS2
+feature. This is the same technology routinely used for full disk
+encryption. The encrypted container is mounted directly through the
+kernel. Unlike other container formats, an encrypted container is not
+decrypted to disk in order to run it.
 
-{Singularity} currently supports 2 types of secrets for encrypted
-containers:
+*********************************
+ Configuration & Runtime Options
+*********************************
 
-   -  *Passphrase*: a text passphrase is passed directly to
-      ``cryptsetup`` for LUKS encryption of the root fs.
+System administrators who manage {Singularity} can use configuration
+files to set security restrictions, grant or revoke a user’s
+capabilities, manage resources and authorize containers etc.
 
-   -  *Asymmetric RSA keypair*: a randomly generated 256-bit secret is
-      used to perform LUKS encryption of the rootfs. This secret is
-      encrypted with a user-provided RSA public key, and the ciphertext
-      stored in the SIF file. At runtime the RSA private key must be
-      provided to decrypt the secret and allow decryption of the root
-      filesystem to use the container.
+For example, the :ref:`Execution Control List <execution_control_list>` file
+allows restricting usage of SIF containers based on their signature
+and the key used to sign them.
 
-.. note::
+Configuration files and their parameters are :ref:`documented for
+administrators here <singularity_configfiles>`.
 
-   You can verify the default LUKS2 cipher and PBKDF on your system by
-   running ``cryptsetup --help``.
-
-   ``cryptsetup`` sets a memory cost for the ``argon2i`` PBKDF based on
-   the RAM available in the system used for encryption, up to a maximum
-   of 1GiB. Encrypted containers created on systems with >2GiB RAM may
-   be unusable on systems with <1GiB of free RAM.
-
-**************************
- Admin Configurable Files
-**************************
-
-{Singularity} Administrators have the ability to access various
-configuration files, that will let them set security restrictions, grant
-or revoke a user’s capabilities, manage resources and authorize
-containers etc. One such file interesting in this context is `ecl.toml
-<https://sylabs.io/guides/{adminversion}/admin-guide/configfiles.html#ecl-toml>`_
-which allows blacklisting and whitelisting of containers. You can find
-all the configuration files and their parameters documented `here
-<https://sylabs.io/guides/{adminversion}/admin-guide/configfiles.html>`__.
-
-cgroups support
-===============
-
-{Singularity} provides native support for ``cgroups``, allowing users to
-limit the resources their containers consume without the help of a
-separate program like a batch scheduling system. This feature helps in
-preventing DoS attacks where one container seizes control of all
-available system resources in order to stop other containers from
-operating properly. To utilize this feature, a user first creates a
-configuration file. An example configuration file is installed by
-default with {Singularity} to provide a guide. At runtime, the
-``--apply-cgroups`` option is used to specify the location of the
-configuration file and cgroups are configured accordingly. More about
-cgroups support `here
-<https://sylabs.io/guides/{adminversion}/admin-guide/configfiles.html#cgroups-toml>`__.
-
-Applying cgroups resource limits on systems using the v2 unified
-hierarchy is supported under {Singularity} v3.9 and above.
-
-``--security`` options
-======================
-
-{Singularity} supports a number of methods for specifying the security
-scope and context when running {Singularity} containers. Additionally,
-it supports new flags that can be passed to the action commands;
-``shell``, ``exec``, and ``run`` allowing fine grained control of
-security. Details about them are documented `here
-<https://sylabs.io/guides/{userversion}/user-guide/security_options.html>`__.
-
-*****************
- Security in SCS
-*****************
-
-`Singularity Container Services (SCS) <https://cloud.sylabs.io>` consist
-of a Remote Builder, a Container Library, and a Keystore. Taken
-together, the Singularity Container Services provide an end-to-end
-solution for packaging and distributing applications in secure and
-trusted containers.
-
-Remote Builder
-==============
-
-As mentioned earlier, the {Singularity} runtime prevents executing code
-with root-level permissions on the host system. But building a container
-requires elevated privileges that most production environments do not
-grant to users. `The Remote Builder <https://cloud.sylabs.io/builder>`_
-solves this challenge by allowing unprivileged users a service that can
-be used to build containers targeting one or more CPU architectures.
-System administrators can use the system to monitor which users are
-building containers, and the contents of those containers. Starting with
-{Singularity} 3.0, the CLI has native integration with the Build Service
-from version 3.0 onwards. In addition, a web GUI interface to the Build
-Service also exists, which allows users to build containers using only a
-web browser.
-
-.. note::
-
-   Please see the :ref:`Fakeroot feature <fakeroot>` which is a secure
-   option for admins in multi-tenant HPC environments and similar use
-   cases where they might want to grant a user special privileges inside
-   a container.
-
-Container Library
-=================
-
-The `Container Library <https://cloud.sylabs.io/library>`_ enables users
-to store and share {Singularity} container images based on the
-Singularity Image Format (SIF). A web front-end allows users to create
-new projects within the Container Library, edit documentation associated
-with container images, and discover container images published by their
-peers.
-
-.. _keystore:
-
-Key Store
-=========
-
-The `Key Store <https://cloud.sylabs.io/keystore>`_ is a key management
-system offered by Sylabs that utilizes `OpenPGP implementation
-<https://gnupg.org/>`_ to facilitate sharing and maintaining of PGP
-public keys used to sign and verify {Singularity} container images. This
-service is based on the OpenPGP HTTP Keyserver Protocol (HKP), with
-several enhancements:
-
--  The Service requires connections to be secured with Transport Layer
-   Security (TLS).
--  The Service implements token-based authentication, allowing only
-   authenticated users to add or modify PGP keys.
--  A web front-end allows users to view and search for PGP keys using a
-   web browser.
-
-Security Considerations of Cloud Services:
-==========================================
-
-#. Communications between users, the auth service and the
-   above-mentioned services are secured via TLS.
-
-#. The services support authentication of users via authentication
-   tokens.
-
-#. There is no implicit trust relationship between Auth and each of
-   these services. Rather, each request between the services is
-   authenticated using the authentication token supplied by the user in
-   the associated request.
-
-#. The services support MongoDB authentication as well as TLS/SSL.
-
-.. note::
-
-   SingularityPRO is a professionally curated and licensed version of
-   Singularity that provides added security, stability, and support
-   beyond that offered by the open source project. Subscribers receive
-   advanced access to security patches through regular updates so, when
-   a CVE is announced publicly PRO subscribers are already using patched
-   software.
-
-Security is not a check box that one can tick and forget. It’s an
-ongoing process that begins with software architecture, and continues
-all the way through to ongoing security practices. In addition to
-ensuring that containers are run without elevated privileges where
-appropriate, and that containers are produced by trusted sources, users
-must monitor their containers for newly discovered vulnerabilities and
-update when necessary just as they would with any other software. Sylabs
-is constantly probing to find and patch vulnerabilities within
-{Singularity}, and will continue to do so.
+When running a container as root, Singularity can apply hardening rules using
+cgroups, seccomp, apparmor. See the 'security options' section of the user
+guide, and :ref:`cgroups.toml documentation <cgroups_toml>`.


### PR DESCRIPTION
This is duplicated (with some link changes) from the user guide. The
same information should be relevant for both audiences (advanced users
and administrators) who wish to consider the security aspects of using
SingularityCE.