### PR TITLE
plugin: add clarification about plugin trust (3.11)

### DIFF
--- a/security.rst
+++ b/security.rst
@@ -213,6 +213,23 @@ kernel. Unlike other container formats, an encrypted container is not
 decrypted to disk in order to run it.
 
 *********************************
+ Plugins
+*********************************
+
+As discussed in the {Singularity} User Guide, `plugins
+<https://sylabs.io/guides/{userversion}/user-guide/plugins.html>`_ provide a way
+to augment Singularity with additional functionality. Before using the
+``singularity plugin compile`` or ``singularity plugin install`` commands to
+compile or add a new plugin to your {Singularity} installation, make sure that
+you trust the origin of the plugin, and that you are certain it does not contain
+any malicious code.
+
+For further information on verifying the contents of SIF files using
+cryptographic signatures, see the `"Sign and Verify" section
+<https://sylabs.io/guides/{userversion}/user-guide/signNverify.html>`_ of the
+{Singularity} User Guide.
+
+*********************************
  Configuration & Runtime Options
 *********************************
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

Pick #110 

This PR adds a subsection about _plugins_ to the Security section, which stresses that an admin should only compile/install a plugin if they trust its source, and directing the reader to the corresponding parts of the User-Guide docs.

