### PR TITLE
Update Windows instructions to WSL2

### DIFF
--- a/installation.rst
+++ b/installation.rst
@@ -873,91 +873,106 @@ targets from the ``builddir`` directory in the source tree:
 
 Linux container runtimes like {Singularity} cannot run natively on
 Windows or Mac because of basic incompatibilities with the host kernel.
-(Contrary to a popular misconception, MacOS does not run on a Linux
+(Contrary to a popular misconception, macOS does not run on a Linux
 kernel. It runs on a kernel called Darwin originally forked from BSD.)
 
-For this reason, the {Singularity} community maintains a set of Vagrant
-Boxes via `Vagrant Cloud <https://www.vagrantup.com/>`__, one of
-`Hashicorp's <https://www.hashicorp.com/#open-source-tools>`_ open
-source tools. The current versions can be found under the `sylabs
-<https://app.vagrantup.com/sylabs>`_ organization.
+To run {Singularity} on a Windows or macOS computer, a Linux virtual machine
+(VM) is required. There are various ways to configure a VM on both Windows and
+macOS. On WIndows, we recommend the Windows Subsystem for Linux (WSL2), and
+macOS, we recommend Lima.
 
 Windows
 =======
 
-Install the following programs:
+Recent builds of Windows 10, and all builds of Windows 11, include version 2 of
+the Windows Subsystem for Linux. WSL2 provides a Linux virtual machine that is
+tightly integrated with the Windows environment. The default Linux distribution
+used by WSL2 is Ubuntu. It is straightforward to install {Singularity} inside
+WSL2 Ubuntu, and use all of its features.
 
--  `Git for Windows <https://git-for-windows.github.io/>`_
--  `VirtualBox for Windows <https://www.virtualbox.org/wiki/Downloads>`_
--  `Vagrant for Windows <https://www.vagrantup.com/downloads.html>`_
--  `Vagrant Manager for Windows <http://vagrantmanager.com/downloads/>`_
-
-{Singularity} Vagrant Box
--------------------------
-
-Run Git Bash (Windows) or open a terminal (Mac) and create and enter a
-directory to be used with your Vagrant VM.
-
-.. code::
-
-   $ mkdir vm-singularity-ce && \
-       cd vm-singularity-ce
-
-If you have already created and used this folder for another VM, you
-will need to destroy the VM and delete the Vagrantfile.
+Follow the `WSL2 installation instructions
+<https://docs.microsoft.com/en-us/windows/wsl/install>`__ to enable WSL2 with
+the default Ubuntu 22.04 environment. On Windows 11 and the most recent builds
+of Windows 10 this is as easy as opening an administrator command prompt or
+Powershell window and entering:
 
 .. code::
 
-   $ vagrant destroy && \
-       rm Vagrantfile
+  wsl --install
 
-Then issue the following commands to bring up the Virtual Machine.
-(Substitute a different value for the ``$VM`` variable if you like.)
+Follow the prompts. A restart is required, and when you open the 'Ubuntu' app
+for the first time you'll be asked to set a username and password for the Linux
+environment.
 
-.. code::
-
-   $ export VM=sylabs/singularity-ce-3.8-ubuntu-bionic64 && \
-       vagrant init $VM && \
-       vagrant up && \
-       vagrant ssh
-
-You can check the installed version of {Singularity} with the following:
+You can install SingularityCE from source, or from the Ubuntu packages at the
+GitHub releases page. To quickly install the 4.0.0 package use the following
+commands inside the WSL2 Ubuntu window:
 
 .. code::
 
-   vagrant@vagrant:~$ singularity version
-   {InstallationVersion}
+  $ wget https://github.com/sylabs/singularity/releases/download/v4.0.0/singularity-ce_4.0.0-jammy_amd64.deb
+  $ sudo apt install ./singularity-ce_4.0.0-jammy_amd64.deb
 
-Of course, you can also start with a plain OS Vagrant box as a base and
-then install {Singularity} using one of the above methods for Linux.
-
-{Singularity} Docker Image
---------------------------
-
-It is possible to use a Dockerized Singularity, here is a sample
-``compose.yaml`` (Singularity version 3.7.4) for use with Docker
-Compose:
+The ``singularity`` command will now be available in your WSL2 environment:
 
 .. code::
 
-   services:
-     singularity:
-       image: quay.io/singularity/singularity:v3.7.4-slim
-       stdin_open: true
-       tty: true
-       privileged: true
-       volumes:
-         - .:/root
-       entrypoint: ["/bin/sh"]
+  $ singularity exec library://ubuntu echo "Hello World!"
+  INFO:    Downloading library image
+  28.4MiB / 28.4MiB [=================================================================================] 100 % 5.6 MiB/s 0s
+  Hello World!
 
-Singularity in Docker can have various disadvantages, but basic
-container operations will work. Currently, the intended use case is
-continuous integration, meaning that you should be able to build a
-Singularity container using this Docker Compose file. For more
-information see `issue#5
-<https://github.com/sylabs/singularity-admindocs/issues/5#issuecomment-852307931>`_
-and the image's source `repo
-<https://github.com/singularityhub/singularity-docker#use-cases>`_
+GPU Support
+-----------
+
+WSL2 supports using an NVIDIA GPU from the Linux environment. To use a GPU from
+{Singularity} in WSL2, you must first install ``libnvidia-container-tools``,
+following the instructions in the `libnvidia-container documentation
+<https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html>`__:
+
+.. code::
+
+  curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg \
+  curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list | \
+    sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | \
+    sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list \
+  sudo apt-get update
+  sudo apt-get install -y nvidia-container-toolkit
+
+Once this process has been completed, GPU containers can be run under WSL2 using
+the ``--nv`` and ``--nvccli`` flags together:
+
+.. code::
+
+  $ singularity pull docker://tensorflow/tensorflow:latest-gpu
+
+  $  singularity run --nv --nvccli tensorflow_latest-gpu.sif
+  INFO:    Setting 'NVIDIA_VISIBLE_DEVICES=all' to emulate legacy GPU binding.
+  INFO:    Setting --writable-tmpfs (required by nvidia-container-cli)
+  ________                               _______________
+  ___  __/__________________________________  ____/__  /________      __
+  __  /  _  _ \_  __ \_  ___/  __ \_  ___/_  /_   __  /_  __ \_ | /| / /
+  _  /   /  __/  / / /(__  )/ /_/ /  /   _  __/   _  / / /_/ /_ |/ |/ /
+  /_/    \___//_/ /_//____/ \____//_/    /_/      /_/  \____/____/|__/
+  You are running this container as user with ID 1000 and group 1000,
+  which should map to the ID and group for your user on the Docker host. Great!
+  Singularity> python
+  Python 3.8.10 (default, Nov 26 2021, 20:14:08)
+  [GCC 9.3.0] on linux
+  Type "help", "copyright", "credits" or "license" for more information.
+  >>> import tensorflow as tf
+  >>> tf.config.list_physical_devices('GPU')
+  2022-03-25 11:42:25.672088: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:922] could not open file to read NUMA node: /sys/bus/pci/devices/0000:01:00.0/numa_node
+  Your kernel may have been built without NUMA support.
+  2022-03-25 11:42:25.713295: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:922] could not open file to read NUMA node: /sys/bus/pci/devices/0000:01:00.0/numa_node
+  Your kernel may have been built without NUMA support.
+  2022-03-25 11:42:25.713892: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:922] could not open file to read NUMA node: /sys/bus/pci/devices/0000:01:00.0/numa_node
+  Your kernel may have been built without NUMA support.
+  [PhysicalDevice(name='/physical_device:GPU:0', device_type='GPU')]
+
+Note that the ``--nvccli`` flag is required to enable container setup using the
+``nvidia-container-cli`` utility. {Singularity}'s simpler library binding
+approach (``--nv`` only) is not sufficient for GPU support under WSL2.
 
 Mac
 ===
@@ -1079,3 +1094,43 @@ To delete the lima VM:
 
    $ limactl delete singularity-ce
 
+{Singularity} Docker Image
+==========================
+
+It is also possible to run {Singularity} inside Docker, or another compatible
+OCI container runtime. This may be convenient if you have Docker Desktop, or a
+similar solution, already installed on your PC or Mac.
+
+Docker containers for {Singularity} are maintained at
+https://quay.io/repository/singularity/singularity. 
+
+.. note::
+
+  These containers are maintained by a third party. They are not part of the
+  {Singularity} project, nor are they reviewed by Sylabs.
+
+An example of a suitable ``compose.yaml`` file to start up {Singularity} in a
+Docker container is given below. Note that privileged operation is needed to
+successfully run {Singularity} nested inside of Docker. Change the version
+number on the ``image:`` line to your preferred release.
+
+.. code::
+
+   services:
+     singularity:
+       image: quay.io/singularity/singularity:v3.11.4-slim
+       stdin_open: true
+       tty: true
+       privileged: true
+       volumes:
+         - .:/root
+       entrypoint: ["/bin/sh"]
+
+Singularity in Docker can have various disadvantages, but basic
+container operations will work. Currently, the intended use case is
+continuous integration, meaning that you should be able to build a
+Singularity container using this Docker Compose file. For more
+information see `issue#5
+<https://github.com/sylabs/singularity-admindocs/issues/5#issuecomment-852307931>`_
+and the image's source `repo
+<https://github.com/singularityhub/singularity-docker#use-cases>`_


### PR DESCRIPTION
Remove Vagrant cloud references.

Move docker image section down, and clarify relationship to the project.

Closes #115